### PR TITLE
Allow Comments on Pull Requests to be Optional

### DIFF
--- a/bin/peanut-gallery
+++ b/bin/peanut-gallery
@@ -12,6 +12,10 @@ var argv = require('yargs')
 	.alias('c', 'commit')
 	.describe('t', 'Specify a GitHub authorization token')
 	.alias('t', 'token')
+	.describe('p', 'Specify if able to comment on a pull request. Enabled by default')
+	.boolean('p')
+	.default('p', true)
+	.alias('p', 'pullrequest')
 	.help('h')
 	.alias('h', 'help')
 	.argv;
@@ -20,7 +24,8 @@ function makeComment(comment) {
 	pg.comment(comment, {
 		repo_slug: argv.r,
 		commit_hash: argv.c,
-		token: argv.t
+		token: argv.t,
+		pull_request: argv.p
 	}, function (err) {
 		if (err) console.error(JSON.stringify(err));
 	});

--- a/bin/peanut-gallery
+++ b/bin/peanut-gallery
@@ -16,6 +16,9 @@ var argv = require('yargs')
 	.boolean('p')
 	.default('p', true)
 	.alias('p', 'pullrequest')
+	.describe('m', 'Specify which branch is your master branch. Set to "master" by default')
+	.default('m', 'master')
+	.alias('m', 'masterbranch')
 	.help('h')
 	.alias('h', 'help')
 	.argv;
@@ -25,7 +28,8 @@ function makeComment(comment) {
 		repo_slug: argv.r,
 		commit_hash: argv.c,
 		token: argv.t,
-		pull_request: argv.p
+		pull_request: argv.p,
+		master_branch: argv.m
 	}, function (err) {
 		if (err) console.error(JSON.stringify(err));
 	});

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ function comment( value, options, cb ) {
 	var commit_hash = opt( options, 'commit_hash', process.env.TRAVIS_COMMIT );
 	var token = opt( options, 'token', process.env.GITHUB_TOKEN );
 	var userAgent = opt( options, 'user_agent', 'peanut-gallery' );
+	var includePullRequests = opt( options, 'pull_request', true );
 
 	var githubUrl = 'https://api.github.com/repos/' + repo_slug + '/commits/' +
 		commit_hash + '/comments';
@@ -45,6 +46,10 @@ function comment( value, options, cb ) {
 
 	}
 
-	request.post( requestOptions, handleResponse );
-
+	if( includePullRequests || process.env.TRAVIS_PULL_REQUEST === 'false' ) {
+		request.post( requestOptions, handleResponse );
+	}
+	else {
+		console.log( 'Peanut gallery is configured not to comment on pull requests.' );
+	}
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ function comment( value, options, cb ) {
 	var token = opt( options, 'token', process.env.GITHUB_TOKEN );
 	var userAgent = opt( options, 'user_agent', 'peanut-gallery' );
 	var includePullRequests = opt( options, 'pull_request', true );
+	var masterBranch = opt( options, 'master_branch', 'master' );
 
 	var githubUrl = 'https://api.github.com/repos/' + repo_slug + '/commits/' +
 		commit_hash + '/comments';
@@ -46,11 +47,8 @@ function comment( value, options, cb ) {
 
 	}
 
-	console.log('IncludePullRequests: ' + includePullRequests );
-	console.log('Is Pull Request?: '  + process.env.TRAVIS_PULL_REQUEST);
-	console.log('Is Master Branch?: '  + process.env.TRAVIS_BRANCH);
 	if( includePullRequests ||
-			(process.env.TRAVIS_PULL_REQUEST === 'false' && process.env.TRAVIS_BRANCH === 'master' ) ) {
+			(process.env.TRAVIS_PULL_REQUEST === 'false' && process.env.TRAVIS_BRANCH === masterBranch ) ) {
 		request.post( requestOptions, handleResponse );
 	}
 	else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,11 @@ function comment( value, options, cb ) {
 
 	}
 
-	if( includePullRequests || process.env.TRAVIS_PULL_REQUEST === 'false' ) {
+	console.log('IncludePullRequests: ' + includePullRequests );
+	console.log('Is Pull Request?: '  + process.env.TRAVIS_PULL_REQUEST);
+	console.log('Is Master Branch?: '  + process.env.TRAVIS_BRANCH);
+	if( includePullRequests ||
+			(process.env.TRAVIS_PULL_REQUEST === 'false' && process.env.TRAVIS_BRANCH === 'master' ) ) {
 		request.post( requestOptions, handleResponse );
 	}
 	else {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-istanbul": "^0.3.1",
     "gulp-jasmine": "^1.0.1",
     "gulp-jshint": "^1.8.5",
-    "nock": "^0.48.0"
+    "nock": "^0.48.0",
+    "sinon": "^1.17.5"
   }
 }

--- a/spec/comment_spec.js
+++ b/spec/comment_spec.js
@@ -3,11 +3,13 @@
 'use strict';
 
 var pg = require('../'),
-	nock = require('nock');
+	nock = require('nock'),
+	request = require('request'),
+	sinon = require('sinon');
 
 describe( 'comment', function() {
 
-	var repo, hash, token, scope;
+	var repo, hash, token, scope, pull_request;
 	var defaultUrl = '/repos/defSlug/commits/defHash/comments';
 
 	beforeEach( function() {
@@ -15,9 +17,11 @@ describe( 'comment', function() {
 		repo = process.env.TRAVIS_REPO_SLUG;
 		hash = process.env.TRAVIS_COMMIT;
 		token = process.env.GITHUB_TOKEN;
+		pull_request = process.env.TRAVIS_PULL_REQUEST;
 		process.env.TRAVIS_REPO_SLUG = 'defSlug';
 		process.env.TRAVIS_COMMIT = 'defHash';
 		process.env.GITHUB_TOKEN = 'defToken';
+		process.env.TRAVIS_PULL_REQUEST = 'false';
 
 		scope = nock( 'https://api.github.com', { allowUnmocked: false } );
 
@@ -28,6 +32,7 @@ describe( 'comment', function() {
 		process.env.TRAVIS_REPO_SLUG = repo;
 		process.env.TRAVIS_COMMIT = hash;
 		process.env.GITHUB_TOKEN = token;
+		process.env.TRAVIS_PULL_REQUEST = pull_request;
 
 	} );
 
@@ -152,4 +157,69 @@ describe( 'comment', function() {
 
 	} );
 
+	it( 'should not be posted on a pull request when specified not to comment on pull requests', function() {
+
+		process.env.TRAVIS_PULL_REQUEST = '7';
+
+		var options = {
+			pull_request: false
+		};
+
+		var requestSpy = sinon.spy(request, 'post');
+
+		pg.comment( '', options, function() { } );
+
+		sinon.assert.notCalled( requestSpy );
+		requestSpy.restore();
+
+	} );
+
+	it( 'should be posted on a pull request when specified to comment on pull requests', function( done ) {
+
+		process.env.TRAVIS_PULL_REQUEST = '8';
+
+		var options = {
+			pull_request: true
+		};
+
+		var requestSpy = sinon.spy(request, 'post');
+
+		pg.comment( '', options, function( ) {
+			done();
+		} );
+
+		sinon.assert.calledOnce( requestSpy );
+		requestSpy.restore();
+
+	} );
+
+	it( 'should be posted on master by default', function( done ) {
+		var requestSpy = sinon.spy(request, 'post');
+
+		var options = {};
+
+		pg.comment( '', options, function( ) {
+			done();
+		} );
+
+		sinon.assert.calledOnce( requestSpy );
+		requestSpy.restore();
+
+	} );
+
+	it( 'should be posted on a master by even if it should not on a pull request', function( done ) {
+		var requestSpy = sinon.spy(request, 'post');
+
+		var options = {
+			pull_request: false
+		};
+
+		pg.comment( '', options, function( ) {
+			done();
+		} );
+
+		sinon.assert.calledOnce( requestSpy );
+		requestSpy.restore();
+
+	} );
 } );


### PR DESCRIPTION
* Add argument to allow comments on pull requests to be optional (`enabled` by default)
* Due to limitation in Travis, you also need to know what the master branch should be (`master` by default)

FYI: @AlexBedley 